### PR TITLE
feature/SY2026-148 현장 전송 이력의 생산계획명 서버 필터 지원

### DIFF
--- a/app/routers/scenario_send.py
+++ b/app/routers/scenario_send.py
@@ -14,6 +14,7 @@ router = APIRouter()
 @router.get("/", response_model=BaseResponse[List[SentProjectHistory]])
 async def get_sent_scenario_history(
     projectName: Optional[str] = Query(None, description="프로젝트 명 검색"),
+    scenarioName: Optional[str] = Query(None, description="생산계획명 검색"),
     projDueMin: Optional[date] = Query(None, description="프로젝트 납기 최소일"),
     projDueMax: Optional[date] = Query(None, description="프로젝트 납기 최대일"),
     scenDueMin: Optional[date] = Query(None, description="시나리오 납기 최소일"),
@@ -25,6 +26,7 @@ async def get_sent_scenario_history(
     data = await scenario_service.get_sent_scenario_history(
         db=db,
         project_name=projectName,
+        scenario_name=scenarioName,
         proj_due_min=projDueMin,
         proj_due_max=projDueMax,
         scen_due_min=scenDueMin,

--- a/app/services/scenario_service.py
+++ b/app/services/scenario_service.py
@@ -724,6 +724,7 @@ async def send_scenario_to_field(db: AsyncSession, scenario_id: int):
 async def get_sent_scenario_history(
     db: AsyncSession,
     project_name: Optional[str] = None,
+    scenario_name: Optional[str] = None,
     proj_due_min: Optional[date] = None,
     proj_due_max: Optional[date] = None,
     scen_due_min: Optional[date] = None,
@@ -744,6 +745,9 @@ async def get_sent_scenario_history(
     # 2. 동적 필터링 적용
     if project_name:
         stmt = stmt.where(Projects.title.ilike(f"%{project_name}%"))
+
+    if scenario_name:
+        stmt = stmt.where(Scenarios.title.ilike(f"%{scenario_name}%"))
         
     if proj_due_min:
         stmt = stmt.where(Projects.project_due >= proj_due_min)

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -532,6 +532,30 @@ async def test_scenario_send_history_filter_project_name(
     assert data[0]["projectTitle"] == "포스코 건설"
 
 
+@pytest.mark.asyncio
+async def test_scenario_send_history_filter_scenario_name(
+    client: AsyncClient, db_session: AsyncSession
+):
+    """scenarioName 필터로 특정 생산계획 이력만 조회"""
+    project = await make_project(db_session, title="포스코 건설")
+    target = await make_scenario(
+        db_session, project.id, status="ORDERED", title="포스코 건설-1차 계획"
+    )
+    other = await make_scenario(
+        db_session, project.id, status="ORDERED", title="포스코 건설-2차 계획"
+    )
+    target.ordered_at = datetime(2026, 3, 1)
+    other.ordered_at = datetime(2026, 3, 2)
+    await db_session.commit()
+
+    response = await client.get("/api/scenario_send/", params={"scenarioName": "1차"})
+
+    data = response.json()["data"]
+    assert len(data) == 1
+    assert len(data[0]["scenarios"]) == 1
+    assert data[0]["scenarios"][0]["scenarioTitle"] == "포스코 건설-1차 계획"
+
+
 # ══════════════════════════════════════════════════════════════════════
 # POST /api/scenario_send/{scenario_id} — 시나리오 현장 전송
 # ══════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## 🔀 PR 제목
- [Feature] 현장 전송 이력의 생산계획명 서버 필터 지원

---

## 📌 작업 내용 요약
어떤 작업을 했는지 간략히 설명해주세요.

예시:
- 현장 전송 이력의 생산계획명 서버 필터 지원

---

## ✅ 체크리스트
PR을 올리기 전에 아래 항목을 확인했나요?

- [ ] 기능 요구사항을 모두 구현했나요?
- [ ] 로컬에서 기능을 직접 테스트했나요?
- [ ] 코드 컨벤션 및 스타일을 지켰나요?
- [ ] 관련된 이슈에 연결했나요?

---

## 🔗 관련 이슈
`Closes #이슈번호` 또는 `Related to #이슈번호` 형태로 작성

예시:
- Closes #93 
- Related to #93 
---

## 📸스크린샷 (선택)

---

## 📎 기타 참고 사항
추가로 리뷰어가 참고해야 할 사항이 있다면 적어주세요.

예시:
- API 명세 변경사항 포함됨
- 테스트 코드는 다음 PR에서 작성 예정